### PR TITLE
remove prune

### DIFF
--- a/lib/support_engine/git/gc.rb
+++ b/lib/support_engine/git/gc.rb
@@ -5,16 +5,6 @@ module SupportEngine
     # Module for handling commits
     class Gc < Base
       class << self
-        # Performs a cleaning of useless git data
-        # @param path [String, Pathname] path to a place where git repo is
-        # @return [Boolean] true if everything went fine
-        # @raise [SupportEngine::Errors::FailedShellCommand] raised when anything went wrong
-        # @example Cleanup current repo
-        #   SupportEngine::Git::Gc.prune(Rails.root) #=> true
-        def prune(path)
-          call_in_path!(path, 'git gc --prune -q')
-          true
-        end
       end
     end
   end

--- a/spec/lib/support_engine/git/gc_spec.rb
+++ b/spec/lib/support_engine/git/gc_spec.rb
@@ -1,25 +1,4 @@
 # frozen_string_literal: true
 
 RSpec.describe SupportEngine::Git::Gc do
-  describe '.prune' do
-    subject(:prune) { described_class.prune(path) }
-
-    context 'when path exist and git repo' do
-      let(:path) { SupportEngine::Git::RepoBuilder::Master.location }
-
-      it { expect(prune).to eq true }
-    end
-
-    context 'when path exist but not git repo' do
-      let(:path) { Pathname.new '/' }
-
-      it { expect { prune }.to raise_error(SupportEngine::Errors::FailedShellCommand) }
-    end
-
-    context 'when path does not exist' do
-      let(:path) { Pathname.new "/#{rand}" }
-
-      it { expect { prune }.to raise_error(SupportEngine::Errors::FailedShellCommand) }
-    end
-  end
 end


### PR DESCRIPTION
once this is merged: https://github.com/coditsu/support-engine/pull/3 and we've updated this branch, we can also merge this.

We no longer run stuff by ourselves but we rely on a clean state from CIs. No need to run prune anywhere.